### PR TITLE
changed error capture in get_participant_table to tuple to fix error 

### DIFF
--- a/cloudos/cohorts/cohort.py
+++ b/cloudos/cohorts/cohort.py
@@ -285,7 +285,7 @@ class Cohort(object):
         for k, v in col_types.items():
             try:
                 res_df[k] = res_df[k].astype(v)
-            except TypeError as e:
+            except (TypeError, ValueError) as e:
                 print(f'Warning: values in the column \"{col_names[k]}\" do not fit the '
                       f'data type ({v}) specified in the Cohort Browser metadata. '
                       f'Leaving data type as `object`.',


### PR DESCRIPTION
## Overview and purpose

Fixes an error in `get_participants_table()` of `cloudos/cohorts/cohort.py` when it was run using pandas 1.4.0 or greater (an error had been changed from TypeError to ValueError).

## How to test
Install from Github. Python >= 3.8 and pip are required.
Clone the repo and install it using pip:

```
git clone https://github.com/lifebit-ai/cloudos-py
cd cloudos-py
git checkout get_phenotype_statistics
pip install -r requirements.txt
pip install -e .
```

```python
>>> from cloudos.cohorts import Cohort, CohortBrowser
>>> apikey = "***"
>>> workspace_id = "5f7c8696d6ea46288645a89f"
>>> cloudos_url = "http://cohort-browser-dev-110043291.eu-west-1.elb.amazonaws.com"
>>> cohort_id = "61cbd1c5b948af25c65ef7d0"

>>> cb = Cohort(apikey, cloudos_url, workspace_id, cohort_id)
```

#### Error


Panda 1.3.5:

```python
>>> df = cb.get_participants_table(cols=None, page_size=100, page_number=0)
Warning: values in the column "Maternal age during pregnancy (years)" do not fit the data type (Int64) specified in the Cohort Browser metadata. Leaving data type as `object`.
>>> print(df)
          i            Sex Maternal age during pregnancy (years)  ...                     During pregnancy Perinatal complications Method of diagnosis
0   1000020  Rare Diseases                          North Thames  ...                           Not Stated                 Unknown            Relative
1   1000035  Rare Diseases                  South West Peninsula  ...               Mixed: White and Asian            Not Supplied            Relative
2   1000061  Rare Diseases                          North Thames  ...                           Not Stated            Not Supplied            Relative
3   1000232         Cancer                            North West  ...                       White: British                     NaN                 NaN
4   1000233  Rare Diseases                          North Thames  ...                           Not Stated            Not Supplied             Proband
..      ...            ...                                   ...  ...                                  ...                     ...                 ...
95  1005097  Rare Diseases                         West Midlands  ...  Asian or Asian British: Bangladeshi                 Unknown             Proband
96  1005143         Cancer                         West Midlands  ...                           Not Stated                     NaN                 NaN
97  1005244  Rare Diseases                            North West  ...                           Not Stated                 Unknown            Relative
98  1005270  Rare Diseases                    Greater Manchester  ...                       White: British            Not Supplied             Proband
99   100529  Rare Diseases                          North Thames  ...                       White: British            Not Supplied            Relative

[100 rows x 7 columns]
```

Panda 1.4.0:

```python
>>> df = cb.get_participants_table(cols=None, page_size=100, page_number=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jonny/Documents/LIfebit/cloudos/cloudos-py/cloudos/cohorts/cohort.py", line 287, in get_participants_table
    res_df[k] = res_df[k].astype(v)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/generic.py", line 5920, in astype
    new_data = self._mgr.astype(dtype=dtype, copy=copy, errors=errors)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/internals/managers.py", line 419, in astype
    return self.apply("astype", dtype=dtype, copy=copy, errors=errors)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/internals/managers.py", line 304, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/internals/blocks.py", line 582, in astype
    new_values = astype_array_safe(values, dtype, copy=copy, errors=errors)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/dtypes/cast.py", line 1292, in astype_array_safe
    new_values = astype_array(values, dtype, copy=copy)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/dtypes/cast.py", line 1237, in astype_array
    values = astype_nansafe(values, dtype, copy=copy)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/dtypes/cast.py", line 1108, in astype_nansafe
    return dtype.construct_array_type()._from_sequence(arr, dtype=dtype, copy=copy)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/arrays/integer.py", line 325, in _from_sequence
    values, mask = coerce_to_array(scalars, dtype=dtype, copy=copy)
  File "/home/jonny/Python_envs/test_cloudos_error/lib/python3.8/site-packages/pandas/core/arrays/integer.py", line 228, in coerce_to_array
    values = values.astype(dtype, copy=copy)
ValueError: invalid literal for int() with base 10: 'North Thames'
```

#### With fix

Pandas 1.3.5: 
```python
>>> df = cb.get_participants_table(cols=None, page_size=100, page_number=0)
Warning: values in the column "Maternal age during pregnancy (years)" do not fit the data type (Int64) specified in the Cohort Browser metadata. Leaving data type as `object`.
>>> print(df)
          i            Sex Maternal age during pregnancy (years)  ...                     During pregnancy Perinatal complications Method of diagnosis
0   1000020  Rare Diseases                          North Thames  ...                           Not Stated                 Unknown            Relative
1   1000035  Rare Diseases                  South West Peninsula  ...               Mixed: White and Asian            Not Supplied            Relative
2   1000061  Rare Diseases                          North Thames  ...                           Not Stated            Not Supplied            Relative
3   1000232         Cancer                            North West  ...                       White: British                     NaN                 NaN
4   1000233  Rare Diseases                          North Thames  ...                           Not Stated            Not Supplied             Proband
..      ...            ...                                   ...  ...                                  ...                     ...                 ...
95  1005097  Rare Diseases                         West Midlands  ...  Asian or Asian British: Bangladeshi                 Unknown             Proband
96  1005143         Cancer                         West Midlands  ...                           Not Stated                     NaN                 NaN
97  1005244  Rare Diseases                            North West  ...                           Not Stated                 Unknown            Relative
98  1005270  Rare Diseases                    Greater Manchester  ...                       White: British            Not Supplied             Proband
99   100529  Rare Diseases                          North Thames  ...                       White: British            Not Supplied            Relative

[100 rows x 7 columns]
```

Pandas 1.4.0:
```python
>>> df = cb.get_participants_table(cols=None, page_size=100, page_number=0)
Warning: values in the column "Maternal age during pregnancy (years)" do not fit the data type (Int64) specified in the Cohort Browser metadata. Leaving data type as `object`.
>>> print(df)
          i            Sex Maternal age during pregnancy (years)  ...                     During pregnancy Perinatal complications Method of diagnosis
0   1000020  Rare Diseases                          North Thames  ...                           Not Stated                 Unknown            Relative
1   1000035  Rare Diseases                  South West Peninsula  ...               Mixed: White and Asian            Not Supplied            Relative
2   1000061  Rare Diseases                          North Thames  ...                           Not Stated            Not Supplied            Relative
3   1000232         Cancer                            North West  ...                       White: British                     NaN                 NaN
4   1000233  Rare Diseases                          North Thames  ...                           Not Stated            Not Supplied             Proband
..      ...            ...                                   ...  ...                                  ...                     ...                 ...
95  1005097  Rare Diseases                         West Midlands  ...  Asian or Asian British: Bangladeshi                 Unknown             Proband
96  1005143         Cancer                         West Midlands  ...                           Not Stated                     NaN                 NaN
97  1005244  Rare Diseases                            North West  ...                           Not Stated                 Unknown            Relative
98  1005270  Rare Diseases                    Greater Manchester  ...                       White: British            Not Supplied             Proband
99   100529  Rare Diseases                          North Thames  ...                       White: British            Not Supplied            Relative

[100 rows x 7 columns]
```