### PR TITLE
feat: add nextflow-profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## lifebit-ai/cloudos-py: changelog
 
-### 0.0.7 - 2022-04-07
+### 0.0.8 - 2022-06-16
+- Adds `--nextflow-profile` parameter to accept nextflow profiles. It
+also makes `--job-config` parameter optional, as a run with only
+profiles is possible.
+
+### 0.0.7a - 2022-04-07
 - Hotfix: extends the wait time from 1s to 60s when checking for job
 status (`--wait-completion true`). This helps preventing API call
 errors from CloudOS API server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## lifebit-ai/cloudos-py: changelog
 
+### 0.0.7 - 2022-04-07
+- Hotfix: extends the wait time from 1s to 60s when checking for job
+status (`--wait-completion true`). This helps preventing API call
+errors from CloudOS API server.
+
 ### 0.0.7 - 2021-03-10
 - Adds support for aborted jobs
 - Adds `--batch` option to `job` subtool to be able to use `batch`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cloudos
 
 __Date:__ 2022-03-10\
-__Version:__ 0.0.7
+__Version:__ 0.0.7a
 
 
 Python package for interacting with CloudOS
@@ -25,7 +25,7 @@ and the `environment.yml` files provided.
 To run the existing docker image at `quay.io`:
 
 ```
-docker run --rm -it quay.io/lifebitai/cloudos-py:v0.0.7
+docker run --rm -it quay.io/lifebitai/cloudos-py:v0.0.7a
 ```
 
 ### From Github

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cloudos
 
-__Date:__ 2022-03-10\
-__Version:__ 0.0.7a
+__Date:__ 2022-06-16\
+__Version:__ 0.0.8
 
 
 Python package for interacting with CloudOS
@@ -25,7 +25,7 @@ and the `environment.yml` files provided.
 To run the existing docker image at `quay.io`:
 
 ```
-docker run --rm -it quay.io/lifebitai/cloudos-py:v0.0.7a
+docker run --rm -it quay.io/lifebitaiorg/cloudos-py:v0.0.8
 ```
 
 ### From Github

--- a/cloudos/__main__.py
+++ b/cloudos/__main__.py
@@ -148,7 +148,7 @@ def run(apikey,
                 if j_status_h != j_status_h_old:
                     print(f'\tYour current job status is: {j_status_h}.')
                     j_status_h_old = j_status_h
-                time.sleep(1)
+                time.sleep(60)
         j_status = j.get_job_status(j_id)
         j_status_h = json.loads(j_status.content)["status"]
         if j_status_h != JOB_COMPLETED:

--- a/cloudos/__main__.py
+++ b/cloudos/__main__.py
@@ -46,9 +46,12 @@ def job():
               help='The name of a CloudOS workflow or pipeline.',
               required=True)
 @click.option('--job-config',
-              help=('A nextflow.config file or similar, with the ' +
-                    'parameters to use with your job.'),
-              required=True)
+              help=('A config file similar to a nextflow.config file, ' +
+                    'but only with the parameters to use with your job.'))
+@click.option('-p',
+              '--nextflow-profile',
+              help=('A comma separated string indicating the nextflow profile/s ' +
+                    'to use with your job.'))
 @click.option('--git-commit',
               help=('The exact whole 40 character commit hash to run for ' +
                     'the selected pipeline. ' +
@@ -99,6 +102,7 @@ def run(apikey,
         job_name,
         resumable,
         batch,
+        nextflow_profile,
         instance_type,
         instance_disk,
         spot,
@@ -120,6 +124,7 @@ def run(apikey,
                       job_name,
                       resumable,
                       batch,
+                      nextflow_profile,
                       instance_type,
                       instance_disk,
                       spot)

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -122,6 +122,7 @@ class Job(Cloudos):
                                  job_name,
                                  resumable,
                                  batch,
+                                 nextflow_profile,
                                  instance_type,
                                  instance_disk,
                                  spot):
@@ -148,6 +149,8 @@ class Job(Cloudos):
             Whether to create a resumable job or not.
         batch: bool
             Whether to create a batch job instead of the default ignite.
+        nextflow_profile: string
+            A comma separated string with the profiles to be used.
         instance_type : string
             Name of the AMI to choose.
         instance_disk : int
@@ -161,34 +164,38 @@ class Job(Cloudos):
             A JSON formatted dict.
         """
         workflow_params = []
-        with open(job_config, 'r') as p:
-            reading = False
-            for p_l in p:
-                if 'params' in p_l.lower():
-                    reading = True
-                else:
-                    if reading:
-                        p_l_strip = p_l.strip().replace(
-                            ' ', '').replace('\"', '').replace('\'', '')
-                        if '}' in p_l_strip:
-                            reading = False
-                        else:
-                            p_list = p_l_strip.split('=')
-                            if len(p_list) != 2:
-                                raise ValueError('Please, specify your ' +
-                                                 'parameters in ' +
-                                                 f'{job_config} using ' +
-                                                 'the \'=\' char as spacer. ' +
-                                                 'E.g: name = my_name')
+        if nextflow_profile is None and job_config is None:
+            raise ValueError('No --job-config or --nextflow_profile was specified, please use ' +
+                             'at least one of these options.')
+        if job_config is not None:
+            with open(job_config, 'r') as p:
+                reading = False
+                for p_l in p:
+                    if 'params' in p_l.lower():
+                        reading = True
+                    else:
+                        if reading:
+                            p_l_strip = p_l.strip().replace(
+                                ' ', '').replace('\"', '').replace('\'', '')
+                            if '}' in p_l_strip:
+                                reading = False
                             else:
-                                param = {"prefix": "--",
-                                         "name": p_list[0],
-                                         "parameterKind": "textValue",
-                                         "textValue": p_list[1]}
-                                workflow_params.append(param)
-        if len(workflow_params) == 0:
-            raise ValueError(f'The {job_config} file did not contain any ' +
-                             'valid parameter')
+                                p_list = p_l_strip.split('=')
+                                if len(p_list) != 2:
+                                    raise ValueError('Please, specify your ' +
+                                                     'parameters in ' +
+                                                     f'{job_config} using ' +
+                                                     'the \'=\' char as spacer. ' +
+                                                     'E.g: name = my_name')
+                                else:
+                                    param = {"prefix": "--",
+                                             "name": p_list[0],
+                                             "parameterKind": "textValue",
+                                             "textValue": p_list[1]}
+                                    workflow_params.append(param)
+            if len(workflow_params) == 0:
+                raise ValueError(f'The {job_config} file did not contain any ' +
+                                 'valid parameter')
         if spot:
             instance_type_block = {
                 "instanceType": instance_type,
@@ -231,6 +238,7 @@ class Job(Cloudos):
                 "optim": "test"
             },
             "revision": revision_block,
+            "profile": nextflow_profile,
             instance: instance_type_block,
             "masterInstance": {
                 "requestedInstance": {
@@ -248,6 +256,7 @@ class Job(Cloudos):
                  job_name,
                  resumable,
                  batch,
+                 nextflow_profile,
                  instance_type,
                  instance_disk,
                  spot):
@@ -270,6 +279,8 @@ class Job(Cloudos):
             Whether to create a resumable job or not.
         batch: bool
             Whether to create a batch job instead of the default ignite.
+        nextflow_profile: string
+            A comma separated string with the profiles to be used.
         instance_type : string
             Type of the AMI to choose.
         instance_disk : int
@@ -300,6 +311,7 @@ class Job(Cloudos):
                                                job_name,
                                                resumable,
                                                batch,
+                                               nextflow_profile,
                                                instance_type,
                                                instance_disk,
                                                spot)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cloudos",
-    version="0.0.7",
+    version="0.0.7a",
     author="David Piñeyro",
     author_email="dapineyro.dev@gmail.com",
     description="Python package for interacting with CloudOS",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cloudos",
-    version="0.0.7a",
+    version="0.0.8",
     author="David Piñeyro",
     author_email="dapineyro.dev@gmail.com",
     description="Python package for interacting with CloudOS",

--- a/test.conf
+++ b/test.conf
@@ -1,3 +1,0 @@
-params {
-    take_n_studies = 2
-}

--- a/test.conf
+++ b/test.conf
@@ -1,0 +1,3 @@
+params {
+    take_n_studies = 2
+}


### PR DESCRIPTION
## Jira Ticket

https://lifebit.atlassian.net/browse/DEL-8247

## Overview

This PR adds the `--nextflow-profile` parameter, to be able to use nextflow profiles.

## Changes

- Increases the API status check time from 1 sec to 60, to minimise the API connection errors. That was the 0.0.7a hotfix that was never merged to `dev`.
- Adds the new `--nextflow-profile` or `-p` to indicate the profile or profiles to use (one profile or a comma separated list of profiles)
- Makes this new parameter and the old `--job-config` optional: you can provide one or both. Adds an `if` to ensure at least one of the parameters is used.

## Test

Run the docker image:
```
docker run --rm -it quay.io/lifebitaiorg/cloudos-py:v0.0.8
```

>NOTE: the jobs may fail as the configs were selected randomly. The point is to see if cloudos-py is managing the profiles correctly.

Job using only `--nextflow-profile test_ebi`: https://staging.lifebit.ai/app/jobs/62ab16511683c70147a07807
![Screenshot from 2022-06-16 14-11-58](https://user-images.githubusercontent.com/45285897/174067001-888d65e7-40ae-4e73-ae2a-57abe8784391.png)

Job using only `--job-config test.conf`: https://staging.lifebit.ai/app/jobs/62ab16f01683c70147a07ae4
![Screenshot from 2022-06-16 14-12-29](https://user-images.githubusercontent.com/45285897/174067082-bcecc5a6-2f7c-4463-b941-1f8e1499b837.png)

Job using both: https://staging.lifebit.ai/app/jobs/62ab16b51683c70147a07a23
![Screenshot from 2022-06-16 14-10-52](https://user-images.githubusercontent.com/45285897/174066849-4eb707db-a472-4afb-bbeb-6161033462ef.png)

Job using neither:

```
CloudOS python package: a package for interacting with CloudOS.

CloudOS job functionality: run and check jobs in CloudOS.

Executing run...
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/dpineyro/Documents/Lifebit/Lifebit_github/cloudos-py/cloudos/__main__.py", line 268, in <module>
    run_cloudos_cli()
  File "/home/dpineyro/.virtualenvs/cloudos/lib/python3.8/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/dpineyro/.virtualenvs/cloudos/lib/python3.8/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/dpineyro/.virtualenvs/cloudos/lib/python3.8/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dpineyro/.virtualenvs/cloudos/lib/python3.8/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dpineyro/.virtualenvs/cloudos/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/dpineyro/.virtualenvs/cloudos/lib/python3.8/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/dpineyro/Documents/Lifebit/Lifebit_github/cloudos-py/cloudos/__main__.py", line 121, in run
    j_id = j.send_job(job_config,
  File "/home/dpineyro/Documents/Lifebit/Lifebit_github/cloudos-py/cloudos/jobs/job.py", line 306, in send_job
    params = self.convert_nextflow_to_json(job_config,
  File "/home/dpineyro/Documents/Lifebit/Lifebit_github/cloudos-py/cloudos/jobs/job.py", line 168, in convert_nextflow_to_json
    raise ValueError('No --job-config or --nextflow_profile was specified, please use' +
ValueError: No --job-config or --nextflow_profile was specified, please use at least one of these options.
```

Job using two profiles `-p test_ebi,testieu`: https://staging.lifebit.ai/app/jobs/62ab1c921683c70147a08a85
![Screenshot from 2022-06-16 14-14-02](https://user-images.githubusercontent.com/45285897/174067303-3b207e35-e8c5-48e8-9d1b-5b02fd517ded.png)

