### PR TITLE
feat: add lustre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## lifebit-ai/cloudos-py: changelog
 
+### 0.0.9 - 2022-06-28
+- Adds support for lustre storage with the new `--storage-mode` and
+`--lustre-size` parameters.
+
 ### 0.0.8 - 2022-06-16
 - Adds `--nextflow-profile` parameter to accept nextflow profiles. It
 also makes `--job-config` parameter optional, as a run with only

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cloudos
 
-__Date:__ 2022-06-16\
-__Version:__ 0.0.8
+__Date:__ 2022-06-28\
+__Version:__ 0.0.9
 
 
 Python package for interacting with CloudOS
@@ -25,7 +25,7 @@ and the `environment.yml` files provided.
 To run the existing docker image at `quay.io`:
 
 ```
-docker run --rm -it quay.io/lifebitaiorg/cloudos-py:v0.0.8
+docker run --rm -it quay.io/lifebitaiorg/cloudos-py:v0.0.9
 ```
 
 ### From Github
@@ -77,35 +77,46 @@ Usage: cloudos job run [OPTIONS]
   Submit a job to CloudOS.
 
 Options:
-  -k, --apikey TEXT        Your CloudOS API key  [required]
-  -c, --cloudos-url TEXT   The CloudOS url you are trying to access to.
-                           Default=https://cloudos.lifebit.ai.
-  --workspace-id TEXT      The specific CloudOS workspace id.  [required]
-  --project-name TEXT      The name of a CloudOS project.  [required]
-  --workflow-name TEXT     The name of a CloudOS workflow or pipeline.
-                           [required]
-  --job-config TEXT        A nextflow.config file or similar, with the
-                           parameters to use with your job.  [required]
-  --git-commit TEXT        The exact whole 40 character commit hash to run for
-                           the selected pipeline. If not specified it defaults
-                           to the last commit of the default branch.
-  --git-tag TEXT           The tag to run for the selected pipeline. If not
-                           specified it defaults to the last commit of the
-                           default branch.
-  --job-name TEXT          The name of the job. Default=new_job.
-  --resumable              Whether to make the job able to be resumed or not.
-  --batch                  Whether to make use the batch executor instead of
-                           the default ignite.
-  --instance-type TEXT     The type of AMI to use. Default=c5.xlarge.
-  --instance-disk INTEGER  The amount of disk storage to configure.
-                           Default=500.
-  --spot                   Whether to make a spot instance.
-  --wait-completion        Whether to wait to job completion and report final
-                           job status.
-  --wait-time INTEGER      Max time to wait (in seconds) to job completion.
-                           Default=3600.
-  --verbose                Whether to print information messages or not.
-  --help                   Show this message and exit.
+  -k, --apikey TEXT            Your CloudOS API key  [required]
+  -c, --cloudos-url TEXT       The CloudOS url you are trying to access to.
+                               Default=https://cloudos.lifebit.ai.
+  --workspace-id TEXT          The specific CloudOS workspace id.  [required]
+  --project-name TEXT          The name of a CloudOS project.  [required]
+  --workflow-name TEXT         The name of a CloudOS workflow or pipeline.
+                               [required]
+  --job-config TEXT            A config file similar to a nextflow.config
+                               file, but only with the parameters to use with
+                               your job.
+  -p, --nextflow-profile TEXT  A comma separated string indicating the
+                               nextflow profile/s to use with your job.
+  --git-commit TEXT            The exact whole 40 character commit hash to run
+                               for the selected pipeline. If not specified it
+                               defaults to the last commit of the default
+                               branch.
+  --git-tag TEXT               The tag to run for the selected pipeline. If
+                               not specified it defaults to the last commit of
+                               the default branch.
+  --job-name TEXT              The name of the job. Default=new_job.
+  --resumable                  Whether to make the job able to be resumed or
+                               not.
+  --batch                      Whether to make use the batch executor instead
+                               of the default ignite.
+  --instance-type TEXT         The type of AMI to use. Default=c5.xlarge.
+  --instance-disk INTEGER      The amount of disk storage to configure.
+                               Default=500.
+  --spot                       Whether to make a spot instance.
+  --storage-mode TEXT          Either 'lustre' or 'regular'. Indicates if the
+                               user wants to select regular or lustre storage.
+                               Default=regular.
+  --lustre-size INTEGER        The lustre storage to be used when --storage-
+                               mode=lustre, in GB. It should be 1200 or a
+                               multiple of it. Default=1200.
+  --wait-completion            Whether to wait to job completion and report
+                               final job status.
+  --wait-time INTEGER          Max time to wait (in seconds) to job
+                               completion. Default=3600.
+  --verbose                    Whether to print information messages or not.
+  --help                       Show this message and exit.
 ```
 
 #### Send a job to CloudOS

--- a/cloudos/__main__.py
+++ b/cloudos/__main__.py
@@ -80,6 +80,15 @@ def job():
 @click.option('--spot',
               help='Whether to make a spot instance.',
               is_flag=True)
+@click.option('--storage-mode',
+              help=('Either \'lustre\' or \'regular\'. Indicates if the user wants to select ' +
+                    'regular or lustre storage. Default=regular.'),
+              default='regular')
+@click.option('--lustre-size',
+              help=('The lustre storage to be used when --storage-mode=lustre, in GB. It should ' +
+                    'be 1200 or a multiple of it. Default=1200.'),
+              type=int,
+              default=1200)
 @click.option('--wait-completion',
               help=('Whether to wait to job completion and report final ' +
                     'job status.'),
@@ -106,6 +115,8 @@ def run(apikey,
         instance_type,
         instance_disk,
         spot,
+        storage_mode,
+        lustre_size,
         wait_completion,
         wait_time,
         verbose):
@@ -127,7 +138,9 @@ def run(apikey,
                       nextflow_profile,
                       instance_type,
                       instance_disk,
-                      spot)
+                      spot,
+                      storage_mode,
+                      lustre_size)
     print(f'\tYour assigned job id is: {j_id}')
     j_url = f'{cloudos_url}/app/jobs/{j_id}'
     if wait_completion:

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -230,6 +230,8 @@ class Job(Cloudos):
         else:
             revision_block = ""
         if storage_mode == "lustre":
+            print('\n[WARNING] Lustre storage has been selected. Please, be sure that this kind of ' +
+                  'storage is available in your CloudOS workspace.\n')
             if lustre_size % 1200:
                 raise ValueError('Please, specify a lustre storage size of 1200 or a multiple of it. ' +
                                  f'{lustre_size} is not a valid number.')

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -230,7 +230,7 @@ class Job(Cloudos):
         else:
             revision_block = ""
         if storage_mode == "lustre":
-            if int(lustre_size) % 1200:
+            if lustre_size % 1200:
                 raise ValueError('Please, specify a lustre storage size of 1200 or a multiple ' +
                                  f'{lustre_size} is not a valid number.')
         if storage_mode not in ['lustre', 'regular']:
@@ -252,7 +252,7 @@ class Job(Cloudos):
                 "computeCostLimit": -1,
                 "optim": "test"
             },
-            "lusterFsxStorageSizeinGb": lustre_size,
+            "lusterFsxStorageSizeInGb": lustre_size,
             "storageMode": storage_mode,
             "revision": revision_block,
             "profile": nextflow_profile,

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -125,7 +125,9 @@ class Job(Cloudos):
                                  nextflow_profile,
                                  instance_type,
                                  instance_disk,
-                                 spot):
+                                 spot,
+                                 storage_mode,
+                                 lustre_size):
         """Converts a nextflow.config file into a json formatted dict.
 
         Parameters
@@ -157,6 +159,12 @@ class Job(Cloudos):
             The disk space of the instance, in GB.
         spot : bool
             Whether to create a spot instance or not.
+        storage_mode : string
+            Either 'lustre' or 'regular'. Indicates if the user wants to select regular
+            or lustre storage.
+        lustre_size : int
+            The lustre storage to be used when --storage-mode=lustre, in GB. It should be 1200 or
+            a multiple of it.
 
         Returns
         -------
@@ -221,6 +229,13 @@ class Job(Cloudos):
                              }
         else:
             revision_block = ""
+        if storage_mode == "lustre":
+            if int(lustre_size) % 1200:
+                raise ValueError('Please, specify a lustre storage size of 1200 or a multiple ' +
+                                 f'{lustre_size} is not a valid number.')
+        if storage_mode is not in ['lustre', 'regular']:
+            raise ValueError('Please, use either \'lustre\' or \'regular\' for --storage-mode ' +
+                             f'{storage_mode} is not allowed')
 
         params = {
             "parameters": workflow_params,
@@ -237,6 +252,8 @@ class Job(Cloudos):
                 "computeCostLimit": -1,
                 "optim": "test"
             },
+            lusterFsxStorageSizeinGb: lustre_size,
+            storageMode: storage_mode,
             "revision": revision_block,
             "profile": nextflow_profile,
             instance: instance_type_block,
@@ -259,7 +276,9 @@ class Job(Cloudos):
                  nextflow_profile,
                  instance_type,
                  instance_disk,
-                 spot):
+                 spot,
+                 storage_mode,
+                 lustre_size):
         """Send a job to CloudOS.
 
         Parameters
@@ -287,6 +306,12 @@ class Job(Cloudos):
             The disk space of the instance, in GB.
         spot : bool
             Whether to create a spot instance or not.
+        storage_mode : string
+            Either 'lustre' or 'regular'. Indicates if the user wants to select regular
+            or lustre storage.
+        lustre_size : int
+            The lustre storage to be used when --storage-mode=lustre, in GB. It should be 1200 or
+            a multiple of it.
 
         Returns
         -------
@@ -314,7 +339,9 @@ class Job(Cloudos):
                                                nextflow_profile,
                                                instance_type,
                                                instance_disk,
-                                               spot)
+                                               spot,
+                                               storage_mode,
+                                               lustre_size)
         r = requests.post("{}/api/v1/jobs?teamId={}".format(cloudos_url,
                                                             workspace_id),
                           data=json.dumps(params), headers=headers)

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -233,7 +233,7 @@ class Job(Cloudos):
             if int(lustre_size) % 1200:
                 raise ValueError('Please, specify a lustre storage size of 1200 or a multiple ' +
                                  f'{lustre_size} is not a valid number.')
-        if storage_mode is not in ['lustre', 'regular']:
+        if storage_mode not in ['lustre', 'regular']:
             raise ValueError('Please, use either \'lustre\' or \'regular\' for --storage-mode ' +
                              f'{storage_mode} is not allowed')
 
@@ -252,8 +252,8 @@ class Job(Cloudos):
                 "computeCostLimit": -1,
                 "optim": "test"
             },
-            lusterFsxStorageSizeinGb: lustre_size,
-            storageMode: storage_mode,
+            "lusterFsxStorageSizeinGb": lustre_size,
+            "storageMode": storage_mode,
             "revision": revision_block,
             "profile": nextflow_profile,
             instance: instance_type_block,

--- a/cloudos/jobs/job.py
+++ b/cloudos/jobs/job.py
@@ -231,7 +231,7 @@ class Job(Cloudos):
             revision_block = ""
         if storage_mode == "lustre":
             if lustre_size % 1200:
-                raise ValueError('Please, specify a lustre storage size of 1200 or a multiple ' +
+                raise ValueError('Please, specify a lustre storage size of 1200 or a multiple of it. ' +
                                  f'{lustre_size} is not a valid number.')
         if storage_mode not in ['lustre', 'regular']:
             raise ValueError('Please, use either \'lustre\' or \'regular\' for --storage-mode ' +

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cloudos",
-    version="0.0.8",
+    version="0.0.9",
     author="David Piñeyro",
     author_email="dapineyro.dev@gmail.com",
     description="Python package for interacting with CloudOS",


### PR DESCRIPTION
## Jira ticket

https://lifebit.atlassian.net/browse/DEL-8715

## Overview

This PR adds support for "lustre" storage by adding two new parameters to `cloudos job run`:
- `--storage-mode`: an string that can be either "regular" or "lustre" to select regular or regular+lustre storage.
- `--lustre-size`: an integer to specify the lustre storage assigned (in Gb). It can be `1200` or a multiple of it.

## Test

Currently, only GEL CloudOS has `lustre` storage activated. To test:

1. Go to any AWS GEL workspace. For this PR, tests were performed on "PRODUCTION":


2. Go to CloudOS: http://cloudos.genomicsengland.internal:443


3. Start a Jupyter notebook with a `bash` terminal.


4. Run the following code:
```
# Run the cloudos-py docker container
docker run --rm -it quay.io/lifebitaiorg/cloudos-py:v0.0.9

# Configure required variables to be reused in several jobs
MY_API_KEY="xxxx"
CLOUDOS="http://172.20.44.70:443"
WORKSPACE_ID="610560f73b66d80011060723"
PROJECT_NAME="testing"
WORKFLOW_NAME="phewas"
GITTAG="stable"
PROFILES="test"
JOBNAME="cloudos-py-lustre"
STORAGEMODE="lustre"
LUSTRESIZE="2400"

# Launch job
cloudos job run \
    -c $CLOUDOS \
    -k $MY_API_KEY \
    --git-tag $GITTAG \
    --job-name $JOBNAME \
    --workspace-id $WORKSPACE_ID \
    --project-name $PROJECT_NAME \
    --workflow-name $WORKFLOW_NAME \
    --nextflow-profile $PROFILES \
    --resumable \
    --storage-mode $STORAGEMODE \
    --lustre-size $LUSTRESIZE \
    --spot
```
> NOTE: CloudOS url should be provided as an IP address rather than with the usual url.

